### PR TITLE
[feat] 마지막 댓글 메뉴버튼 상단 띄움

### DIFF
--- a/pawrest/Core/Components/Community/Comment/CommunityCommentRow.swift
+++ b/pawrest/Core/Components/Community/Comment/CommunityCommentRow.swift
@@ -26,6 +26,8 @@ struct CommunityCommentRow: View {
     let comment: Comment
     var isReply: Bool = false
     var isMyComment: Bool = false
+    var opensMenuUpward: Bool = false
+    
     let onAction: (Action) -> Void
     
     @State private var isMenuOpen = false
@@ -143,6 +145,7 @@ private extension CommunityCommentRow {
                 icon: .iconReplyMore,
                 size: .comment,
                 showsEdit: false,
+                opensUpward: opensMenuUpward,
                 onEdit: { onAction(.editTapped) },
                 onDelete: { onAction(.deleteTapped) },
                 onMenuVisibilityChanged: { isMenuOpen = $0 }
@@ -151,6 +154,7 @@ private extension CommunityCommentRow {
             ReportMenuButton (
                 icon: .iconReplyMore,
                 size :.comment,
+                opensUpward: opensMenuUpward,
                 onBoardSettings: { onAction(.reportBoardSettings)},
                 onReportAbuse: { onAction(.reportAbuse)},
                 onReportSpam: { onAction(.reportSpam)},

--- a/pawrest/Core/Components/EditMenuButton.swift
+++ b/pawrest/Core/Components/EditMenuButton.swift
@@ -33,6 +33,7 @@ struct EditMenuButton: View {
     var size: MenuButtonStyle = .defaultStyle
     var iconColor: Color = .gray80
     var showsEdit: Bool = true
+    var opensUpward: Bool = false
     
     let onEdit: () -> Void
     let onDelete: () -> Void
@@ -112,7 +113,7 @@ struct EditMenuButton: View {
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(.gray20, lineWidth: 1)
                 )
-                .offset(x: 0, y: size.buttonSize + 6)
+                .offset(x: 0, y: opensUpward ? -(showsEdit ? 86 : 50) : size.buttonSize + 6)
                 .zIndex(1000)
             }
         }

--- a/pawrest/Core/Components/EditMenuButton.swift
+++ b/pawrest/Core/Components/EditMenuButton.swift
@@ -113,7 +113,7 @@ struct EditMenuButton: View {
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(.gray20, lineWidth: 1)
                 )
-                .offset(x: 0, y: opensUpward ? -(showsEdit ? 86 : 50) : size.buttonSize + 6)
+                .offset(x: 0, y: opensUpward ? -(showsEdit ? 86 : 52) : size.buttonSize + 6)
                 .zIndex(1000)
             }
         }

--- a/pawrest/Core/Components/ReportMenuButton.swift
+++ b/pawrest/Core/Components/ReportMenuButton.swift
@@ -150,7 +150,7 @@ struct ReportMenuButton: View {
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(.gray20, lineWidth: 1)
                 )
-                .offset(x: 0, y: opensUpward ? (isExpanded ? -224 : -96) : size.buttonSize + 6)
+                .offset(x: 0, y: opensUpward ? (isExpanded ? -190 : -86) : size.buttonSize + 6)
                 .zIndex(1000)
             }
         }

--- a/pawrest/Core/Components/ReportMenuButton.swift
+++ b/pawrest/Core/Components/ReportMenuButton.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct ReportMenuButton: View {
     let icon: ImageResource
     var size: MenuButtonStyle = .defaultStyle
+    var opensUpward: Bool = false
     
     let onBoardSettings: () -> Void
     let onReportAbuse: () -> Void
@@ -149,7 +150,7 @@ struct ReportMenuButton: View {
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(.gray20, lineWidth: 1)
                 )
-                .offset(x: 0, y: size.buttonSize + 6)
+                .offset(x: 0, y: opensUpward ? (isExpanded ? -224 : -96) : size.buttonSize + 6)
                 .zIndex(1000)
             }
         }

--- a/pawrest/Features/Scene/Community/CommunityDetail/CommunityDetailView.swift
+++ b/pawrest/Features/Scene/Community/CommunityDetail/CommunityDetailView.swift
@@ -173,6 +173,7 @@ private extension CommunityDetailView {
             comment: parent,
             isReply: false,
             isMyComment: parent.author.id == store.currentUserID,
+            opensMenuUpward: isLastGroup && parent.replies.isEmpty,
             onAction: { action in
                 store.send(.commentAction(commentID: parent.id, action: action))
             }
@@ -191,6 +192,7 @@ private extension CommunityDetailView {
                     comment: reply,
                     isReply: true,
                     isMyComment: reply.author.id == store.currentUserID,
+                    opensMenuUpward: isLastGroup && rIdx == parent.replies.count - 1,
                     onAction: { action in
                         store.send(.commentAction(commentID: reply.id, action: action))
                     }


### PR DESCRIPTION

## 🔥 Related Issue
- close #34

---

## 💡 What’s Changed

<!-- 무엇을 변경했는지 -->

### 변경된 파일 

```swift

```
---


## 📸 Screenshot (optional)

<!-- UI 변경 시 첨부 -->
<img width="516" height="980" alt="Screenshot 2026-06-18 at 02 44 09" src="https://github.com/user-attachments/assets/c5419b51-232e-42b4-a095-2a3669944431" />
<img width="516" height="980" alt="Screenshot 2026-06-18 at 02 45 45" src="https://github.com/user-attachments/assets/5debe7da-0c4a-495d-9805-a21025986cd1" />
<img width="516" height="980" alt="Screenshot 2026-06-18 at 02 45 48" src="https://github.com/user-attachments/assets/e72d904a-8a8c-4d83-9df8-5b355952ad51" />

---

## 🚨 Note

<!-- 리뷰어가 꼭 봐야할 부분 -->

사진보단 더 아래 일정하게 뜨게 일단 눈대중으로 값 맞춰놓음 
